### PR TITLE
Switch from prefer-default-export export to no-default-export

### DIFF
--- a/eslint-config-react/index.js
+++ b/eslint-config-react/index.js
@@ -34,6 +34,8 @@ module.exports = {
         "react/function-component-definition": [1, {
             "namedComponents":  "arrow-function",
             "unnamedComponents": "arrow-function"
-        }]
+        }],
+        "import/prefer-default-export": "off",
+        "import/no-default-export": "warn"
     },
 };

--- a/eslint-config-react/package-lock.json
+++ b/eslint-config-react/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quartr/eslint-config-react",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/eslint-config-react/package.json
+++ b/eslint-config-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quartr/eslint-config-react",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "main": "index.js",
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
I've recently proposed in our web channel to start replacing the existing default imports from the projects with named imports. 

Reasons why named imports are preferable:
- It allows us to use variable names that are different from the imports (you always have to check the imports to be sure `variableA` actually comes from const `variableA = require('./variableA')`).
- Default imports are not compatible with named imports, so whenever you have to add a new export, you have a breaking change in the consumers.
- It makes it harder to refactor the code - with named imports, the IDEs can do all the manual work for you. Example: https://share.getcloudapp.com/E0uggeP4

Since everyone agreed with this change, I am updating the ESLint rules accordingly.

OBS:
In order for this migration to be smooth, I decided to start by only throwing warnings for now in default export cases. This way we don't need to deal with all the existing cases immediatly. Once most of the cases are migrated, we can switch from `warn` to `error`.

